### PR TITLE
libxcdbus: segfault when the bus is unavailable

### DIFF
--- a/src/xcdbus.c
+++ b/src/xcdbus.c
@@ -219,6 +219,9 @@ xcdbus_init2(const char *service_name, DBusGConnection *connG)
 {
   xcdbus_conn_t *c = xcdbus_init_common(service_name, connG, 0);
 
+  if (!c)
+      return NULL;
+
   /* setup watching */
   dbus_connection_set_watch_functions (
       c->conn,
@@ -340,6 +343,10 @@ EXTERNAL xcdbus_conn_t *
 xcdbus_init_event(const char *service_name, DBusGConnection *connG)
 {
   xcdbus_conn_t *c = xcdbus_init_common(service_name, connG, 0);
+
+  if (!c)
+      return NULL;
+
   /* setup watching */
   dbus_connection_set_watch_functions (
       c->conn,


### PR DESCRIPTION
Assuming dbus_g_connection_get_connection failed to return a
DBusGConnection, programs linking libxcdbus and calling:
- xcdbus_init2
- xcdbus_init_event
will crash.
